### PR TITLE
William test check

### DIFF
--- a/api/apiRouter.test.js
+++ b/api/apiRouter.test.js
@@ -30,3 +30,31 @@ describe("/api/users endpoint", () => {
     expect(response.body.healthy).toBe(true);
   });
 });
+
+describe("/api/socks endpoint", () => {
+  // close db connection and supertest server tcp connection
+  afterAll(async () => {
+    await client.end();
+    handle.close();
+  });
+
+  it("should respond with { message: Socks API up and runnning. }", async () => {
+    const response = await request.get("/api/health");
+    expect(response.status).toBe(200);
+    expect(response.body.healthy).toBe(true);
+  });
+});
+
+describe("/api/address endpoint", () => {
+  // close db connection and supertest server tcp connection
+  afterAll(async () => {
+    await client.end();
+    handle.close();
+  });
+
+  it("should respond with { message: Addresses API up and running }", async () => {
+    const response = await request.get("/api/health");
+    expect(response.status).toBe(200);
+    expect(response.body.healthy).toBe(true);
+  });
+});

--- a/api/apiRouter.test.js
+++ b/api/apiRouter.test.js
@@ -1,17 +1,31 @@
-const { server, handle } = require('../index');
-const { client } = require('../db');
-const supertest = require('supertest');
+const { server, handle } = require("../index");
+const { client } = require("../db");
+const supertest = require("supertest");
 const request = supertest(server);
 
-describe('/api/health endpoint', () => {
+describe("/api/health endpoint", () => {
   // close db connection and supertest server tcp connection
   afterAll(async () => {
     await client.end();
     handle.close();
   });
 
-  it('should respond with { healthy: true }', async () => {
-    const response = await request.get('/api/health');
+  it("should respond with { healthy: true }", async () => {
+    const response = await request.get("/api/health");
+    expect(response.status).toBe(200);
+    expect(response.body.healthy).toBe(true);
+  });
+});
+
+describe("/api/users endpoint", () => {
+  // close db connection and supertest server tcp connection
+  afterAll(async () => {
+    await client.end();
+    handle.close();
+  });
+
+  it("should respond with { healthy: true }", async () => {
+    const response = await request.get("/api/health");
     expect(response.status).toBe(200);
     expect(response.body.healthy).toBe(true);
   });


### PR DESCRIPTION
added some initial API tests for users, addresses, socks, and users. Would like to build these out so that they function in relation to the response not just saying that the route is healthy. i.e make sure that the response from users/register has all of the fields we want etc... 

should be good for now and give a build base for future tests but certainly should be built upon 