### PR TITLE
fix: adds extra D to adress typos

### DIFF
--- a/db/init_db.js
+++ b/db/init_db.js
@@ -36,7 +36,7 @@ async function buildTables() {
 
       CREATE TABLE addresses (
         id SERIAL PRIMARY KEY,
-        adress_line VARCHAR(255) NOT NULL,
+        address_line VARCHAR(255) NOT NULL,
         state VARCHAR(2) NOT NULL,
         city VARCHAR(255) NOT NULL,
         zipcode VARCHAR(5) NOT NULL
@@ -171,7 +171,7 @@ async function populateInitialData() {
       orderDetailsToCreate.map(OrderDetails.createOrderDetails)
     );
     const orderItems = await Promise.all(
-      orderItemsToCreate.map(OrderItems.createOrderDetails)
+      orderItemsToCreate.map(OrderItems.createOrderItems)
     );
     [
       (users,

--- a/db/models/addresses.js
+++ b/db/models/addresses.js
@@ -4,16 +4,16 @@ module.exports = {
   createAddresses,
 };
 
-async function createAddresses({ adress_line, state, city, zipcode }) {
+async function createAddresses({ address_line, state, city, zipcode }) {
   try {
     const {
       rows: [adresses],
     } = await client.query(
       `
-    INSERT INTO addresses (adress_line, state, city, zipcode)
+    INSERT INTO addresses (address_line, state, city, zipcode)
     VALUES ($1, $2, $3, $4)
     RETURNING *;`,
-      [adress_line, state, city, zipcode]
+      [address_line, state, city, zipcode]
     );
     return adresses;
   } catch (err) {


### PR DESCRIPTION
We accidentally brought a breaking bug into our main branch via a typo on address. Because of this trying to spin up the database would result in an error that address_line was null even when a value was defined because the key-value pair was misspelled. With this fix, the main should be bug-free  